### PR TITLE
Nothing to see here no. 5

### DIFF
--- a/astrobot/webapp.py
+++ b/astrobot/webapp.py
@@ -77,24 +77,17 @@ def hook():
     # ends up below the merge message.
     time.sleep(2)
 
-    # Troll mode on special day for new issue or pull request
+    # Troll mode on special day for new pull request
     tt = time.gmtime()  # UTC because we're astronomers!
-    # TODO: After test, change to tt.tm_mon == 4 and tt.tm_mday == 1
-    if (tt.tm_mon == 3 and tt.tm_mday > 26 and
-            request.headers['X-GitHub-Event'] in ('issue', 'pull_request') and
+    if (tt.tm_mon == 4 and tt.tm_mday == 1 and
+            request.headers['X-GitHub-Event'] == 'pull_request' and
             request.json['action'] == 'opened'):
         import random
 
         gh = Github(login_or_token=GITHUB_TOKEN)
-
-        if request.headers['X-GitHub-Event'] == 'pull_request':
-            repo = gh.get_repo(
-                request.json['pull_request']['base']['repo']['full_name'])
-            pr = repo.get_pull(int(request.json['number']))
-        else:  # issue
-            repo = gh.get_repo(
-                request.json['issue']['base']['repo']['full_name'])
-            pr = repo.get_issue(int(request.json['number']))
+        repo = gh.get_repo(
+            request.json['pull_request']['base']['repo']['full_name'])
+        pr = repo.get_pull(int(request.json['number']))
 
         try:
             q = random.choice(QUOTES)


### PR DESCRIPTION
Never did fix the logic to only issue special message on "experimental" only on special day (it was done in "production" though).

Also, removed the logic for opening new issue (not done in "production" but should not matter unless you have OCD) because:
1. It didn't work; didn't raise any exception into issue comment, just didn't do anything at all.
2. You need to set up hooks for "issues" in addition to "pull requests", so the logic would be unused anyway if people simply follow the published instructions.

Since Apr 1, 2017 fell on a Saturday, I thought this wouldn't run at all. Was I surprised! We'll see again next year. :wink: 